### PR TITLE
Enh/precision estimator

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,19 @@
+[run]
+branch = True
+omit =
+    */setup.py
+    skmediate/_version.py
+    skmediate/tests/*.py
+
+[report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    if self.debug:
+    if settings.DEBUG
+    raise AssertionError
+    raise NotImplementedError
+    if 0:
+    if __name__ == .__main__.:
+    if self.verbose:
+show_missing = True

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,0 @@
-[flake8]
-max-line-length = 88
-select = C,E,F,W,B,B950
-ignore = E501,N802,N806,W503,E203
-exclude = setup.py,build,dist,docs,.ipynb_checkpoints

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: flake lint
+
+flake:
+	flake8
+	black --check .
+	pydocstyle
+
+lint: flake
+
+test:
+    # Unit testing using pytest
+	pytest --pyargs skmediate --cov-report term-missing --cov-config .coveragerc --cov=skmediate
+
+devtest:
+    # Unit testing with the -x option, aborts testing after first failure
+    # Useful for development when tests are long
+	pytest -x --pyargs skmediate --cov-report term-missing --cov-config .coveragerc --cov=skmediate

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,14 @@ maint =
 
 [pydocstyle]
 convention = numpy
+match = (?!_version).*\.py
 match-dir = skmediate
+
+[flake8]
+max-line-length = 88
+select = C,E,F,W,B,B950
+ignore = E501,N802,N806,W503,E203
+exclude = setup.py,build,dist,docs,.ipynb_checkpoints
 
 # All configuration for plugins and other utils is defined here.
 # Read more about `setup.cfg`:

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,8 +39,7 @@ install_requires =
     numpy==1.19.1
     scikit-learn==0.23.2
     scipy==1.5.2
-    pandas
-    statsmodels
+    tqdm
 zip_safe = False
 include_package_data = True
 packages = find:

--- a/skmediate/conditional_independence.py
+++ b/skmediate/conditional_independence.py
@@ -1,8 +1,9 @@
 """Classes for computations of conditional independence."""
-import collections
 import numpy as np
 import warnings
 
+from collections.abc import Sequence
+from inspect import getmro
 from sklearn.base import clone, RegressorMixin
 from sklearn.linear_model import LinearRegression
 from sklearn.covariance import (
@@ -16,7 +17,6 @@ from sklearn.covariance import (
 )
 from sklearn.utils import shuffle
 from tqdm.auto import trange
-from inspect import getmro
 
 
 COV_ESTIMATORS = {
@@ -129,7 +129,7 @@ class ConditionalCrossCovariance(object):
         if regression_estimator is None:
             self.regression_estimator_xz = LinearRegression()
             self.regression_estimator_xy = LinearRegression()
-        elif isinstance(regression_estimator, collections.Sequence):
+        elif isinstance(regression_estimator, Sequence):
             if not all(isinstance(r, RegressorMixin) for r in regression_estimator):
                 mro = [getmro(type(r)) for r in regression_estimator]
                 raise ValueError(

--- a/skmediate/conditional_independence.py
+++ b/skmediate/conditional_independence.py
@@ -243,6 +243,8 @@ class ConditionalCrossCovariance(object):
                         @ shuffle_prec_yy_
                     ).flatten()
                 )
+            
+            self.null_distribution_ = rcc_shuffle
 
             self.rcc_p_value_ = (
                 np.sum(rcc_shuffle >= self.residual_crosscovariance_, axis=0)

--- a/skmediate/conditional_independence.py
+++ b/skmediate/conditional_independence.py
@@ -245,8 +245,7 @@ class ConditionalCrossCovariance(object):
                 )
 
             self.rcc_p_value_ = (
-                1
-                - np.count_nonzero(self.residual_crosscovariance_ > rcc_shuffle, axis=0)
+                np.sum(rcc_shuffle > self.residual_crosscovariance_, axis=0)
                 / self.n_shuffle
             )
 

--- a/skmediate/conditional_independence.py
+++ b/skmediate/conditional_independence.py
@@ -87,6 +87,37 @@ class ConditionalCrossCovariance(object):
             If True, show a progress bar while estimating the p-value
             Default: True
 
+        Attributes
+        ----------
+        regression_estimator_{xz, xy} : sklearn estimator class
+            The fitted regression estimators
+
+        residualized_{Y,Z}_ : numpy.ndarray
+            The residualized ``X``, ``Y``, and ``Z`` matrices
+
+        covfit_{yy,zy,zz}_ : sklearn covariance estimator class
+            The fitted covariance estimator for Y, Z, and YZ.
+
+        cov_zy_ : numpy.ndarray
+            The cross-covariance matrix for Y and Z
+
+        prec_{yy,zz}_ : numpy.ndarray
+            The precision matrix for Y and Z, respectively
+
+        residual_crosscovariance_ : float
+            The residualized cross-covariance
+
+        residual_crosscovariance_wherry_corrected_ : float
+            The residualized cross-covariance with bias corrected using the
+            Wherry formula. This may or may not be appropriate depending on the
+            type of covariance and precision estimators.
+
+        null_distribution_ : numpy.ndarray
+            Array of simulated null distribution values
+
+        rcc_p_value_ : float
+            Estimated p value for the ``residual_crosscovariance_`` point estimate
+
         Notes
         -----
         .. [1] Wim Van der Elst, Ariel Abad Alonso, Helena Geys, Paul Meyvisch,
@@ -243,8 +274,8 @@ class ConditionalCrossCovariance(object):
                         @ shuffle_prec_yy_
                     ).flatten()
                 )
-            
-            self.null_distribution_ = rcc_shuffle
+
+            self.null_distribution_ = np.array(rcc_shuffle)
 
             self.rcc_p_value_ = (
                 np.sum(rcc_shuffle >= self.residual_crosscovariance_, axis=0)

--- a/skmediate/conditional_independence.py
+++ b/skmediate/conditional_independence.py
@@ -1,7 +1,7 @@
 """Classes for computations of conditional independence."""
 import collections
 import numpy as np
-from scipy import linalg
+
 from sklearn.base import clone, RegressorMixin
 from sklearn.linear_model import LinearRegression
 from sklearn.covariance import EmpiricalCovariance

--- a/skmediate/conditional_independence.py
+++ b/skmediate/conditional_independence.py
@@ -245,7 +245,7 @@ class ConditionalCrossCovariance(object):
                 )
 
             self.rcc_p_value_ = (
-                np.sum(rcc_shuffle > self.residual_crosscovariance_, axis=0)
+                np.sum(rcc_shuffle >= self.residual_crosscovariance_, axis=0)
                 / self.n_shuffle
             )
 

--- a/skmediate/conditional_independence.py
+++ b/skmediate/conditional_independence.py
@@ -260,7 +260,7 @@ class ConditionalCrossCovariance(object):
                 shuffle_range = range(self.n_shuffle)
 
             for n in shuffle_range:
-                shuffle_Y = shuffle(Y)
+                shuffle_Y = shuffle(self.residualized_Y_)
 
                 shuffle_W = np.concatenate((shuffle_Y, self.residualized_Z_), axis=1)
                 shuffle_covfit_zy_ = shuffle_cov_est.fit(shuffle_W)

--- a/skmediate/tests/test_conditional_independence.py
+++ b/skmediate/tests/test_conditional_independence.py
@@ -1,23 +1,60 @@
 """Tests for functions in conditonal independence """
 
 import numpy as np
-from skmediate.conditional_independence import ConditionalCrossCovariance
+import pytest
+import warnings
+
 from sklearn.linear_model import Ridge, LinearRegression
+from skmediate.conditional_independence import ConditionalCrossCovariance
 
 
 def test_conditional_independence():
-
     X = np.random.randn(10, 1)
     Z = np.random.randn(10, 5)
     Y = np.random.randn(10, 1)
 
     xcov_estimator = ConditionalCrossCovariance()
-    xcov_estimator.fit(X, Z, Y)
+    xcov_estimator.fit(Z, Y, X)
 
     xcov_estimator = ConditionalCrossCovariance(
         regression_estimator=[Ridge(), LinearRegression()]
     )
-    xcov_estimator.fit(X, Z, Y)
+    xcov_estimator.fit(Z, Y, X)
 
-    xcov_estimator = ConditionalCrossCovariance(Ridge())
-    xcov_estimator.fit(X, Z, Y)
+    xcov_estimator = ConditionalCrossCovariance(Ridge(), residualized=True)
+    xcov_estimator.fit(Z, Y)
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        xcov_estimator.fit(Z, Y, X)
+        # Verify warning
+        assert len(w) == 1
+        assert "residualized" in str(w[-1].message)
+
+    xcov_estimator = ConditionalCrossCovariance(
+        covariance_estimator="ledoit_wolf",
+        precision_estimator="min_cov_det",
+        estimate_p_value=True,
+        show_progress=False
+    )
+    xcov_estimator.fit(Z, Y, X)
+
+    xcov_estimator = ConditionalCrossCovariance(
+        covariance_estimator="ledoit_wolf",
+        precision_estimator="min_cov_det",
+        estimate_p_value=True,
+        show_progress=True
+    )
+    xcov_estimator.fit(Z, Y, X)
+
+    with pytest.raises(ValueError):
+        ConditionalCrossCovariance(regression_estimator=[22, "error"])
+
+    with pytest.raises(ValueError):
+        ConditionalCrossCovariance(regression_estimator=22)
+
+    with pytest.raises(ValueError):
+        ConditionalCrossCovariance(covariance_estimator="error")
+
+    with pytest.raises(ValueError):
+        ConditionalCrossCovariance(precision_estimator="error")

--- a/skmediate/tests/test_conditional_independence.py
+++ b/skmediate/tests/test_conditional_independence.py
@@ -35,7 +35,7 @@ def test_conditional_independence():
         covariance_estimator="ledoit_wolf",
         precision_estimator="min_cov_det",
         estimate_p_value=True,
-        show_progress=False
+        show_progress=False,
     )
     xcov_estimator.fit(Z, Y, X)
 
@@ -43,7 +43,7 @@ def test_conditional_independence():
         covariance_estimator="ledoit_wolf",
         precision_estimator="min_cov_det",
         estimate_p_value=True,
-        show_progress=True
+        show_progress=True,
     )
     xcov_estimator.fit(Z, Y, X)
 

--- a/skmediate/tests/test_datasets.py
+++ b/skmediate/tests/test_datasets.py
@@ -1,5 +1,5 @@
 # import numpy as np
-# import pytest
+import pytest
 
 from skmediate.datasets import make_null_mediation, make_mediation
 
@@ -7,12 +7,18 @@ from skmediate.datasets import make_null_mediation, make_mediation
 # from sklearn.utils._testing import assert_raises
 
 
-def test_make_null_mediation():
+@pytest.mark.parametrize("n_mediators", [1, 2, 3])
+@pytest.mark.parametrize("dag_type", ["null-dag1", "null-dag2", "null-dag3"])
+def test_make_null_mediation(n_mediators, dag_type):
     # Smoke test
-    answer = make_null_mediation()
+    answer = make_null_mediation(n_mediators=n_mediators, dag_type=dag_type)
     assert len(answer) == 6
 
 
-def test_make_mediation():
-    answer = make_mediation()
+@pytest.mark.parametrize("n_mediators", [1, 2, 3])
+def test_make_mediation(n_mediators):
+    answer = make_mediation(n_mediators=n_mediators)
+    assert len(answer) == 6
+
+    answer = make_mediation(n_mediators=n_mediators, n_informative_mo=1)
     assert len(answer) == 6


### PR DESCRIPTION
## Description

This PR
- reverses the order of Y, Z in the computation of covariance for better accordance with the reference text.
- Clones the input regressors and covariance estimators so that they can be separately fit
- Uses the input precision estimators to compute the `yy` and `zz` precisions. This is especially important for high-dimensional data where one might want to use e.g. `LedoitWolf()` to estimate the precision.
- Adds convenience string parameters for input so that the use doesn't have to import various covariance estimators

## Related Issue

Resolves #16 
Resolves #17

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/mnarayan/skmediate/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/mnarayan/skmediate/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.

BTW, I can't do `make codestyle` because I can't find the Makefile.